### PR TITLE
Fix duplicate monthly playlists with Spotify API fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,12 +30,14 @@ class Playlist:
     songs: Optional[List[Song]]
     id: str
     name: str
+    owner_id: str
     sp: Spotify
 
     def __init__(self, sp: Spotify, playlist: dict) -> None:
         self.sp = sp
         self.name = playlist['name']
         self.id = playlist['id']
+        self.owner_id = playlist.get('owner', {}).get('id', '')
         self.songs = None
 
     def add_song(self, song: Song):
@@ -66,15 +68,25 @@ class Playlist:
         :return: True for success, False otherwise.
         """
 
-        try:
-            results = self.sp.playlist_items(
-                playlist_id=self.id, additional_types=('track',))
-        except Exception as e:
-            print(repr(e))
-            return False
-        if 'items' not in results:
-            return False
-        self.songs = [Song(x) for x in results['items']]
+        self.songs = []
+        offset = 0
+        limit = 100
+
+        while True:
+            try:
+                results = self.sp.playlist_items(
+                    playlist_id=self.id, additional_types=('track',),
+                    limit=limit, offset=offset)
+            except Exception as e:
+                print(repr(e))
+                return False
+            if 'items' not in results:
+                return False
+            self.songs.extend(Song(x) for x in results['items'])
+            if len(results['items']) < limit:
+                break
+            offset += limit
+
         return True
 
 
@@ -210,12 +222,33 @@ class MonthlyPlaylists:
     def __find_playlist(self, name: str) -> Optional[Playlist]:
         """Returns a playlist matching the given name or creates one.
 
+        First checks locally fetched playlists, then searches via Spotify's
+        search API as a fallback (avoids duplicates when the playlist wasn't
+        returned by the paginated listing).
+
         :param name: The title of the playlist to search for or create.
         :return: Playlist if successful, None otherwise.
         """
 
-        playlist = next((x for x in self.playlists if x.name == name), None)
-        # If playlist does not exist attempt to create it
+        # Check locally fetched playlists first
+        playlist = next(
+            (x for x in self.playlists if x.name == name and x.owner_id == self.user_id),
+            None)
+
+        # Fallback: search via Spotify's search API
+        if playlist is None:
+            try:
+                results = self.sp.search(q=name, type='playlist', limit=50)
+                for item in results.get('playlists', {}).get('items', []):
+                    if item['name'] == name and item.get('owner', {}).get('id') == self.user_id:
+                        playlist = Playlist(sp=self.sp, playlist=item)
+                        self.playlists.append(playlist)
+                        print(f'Found existing playlist "{name}" via search')
+                        break
+            except Exception as e:
+                print(f'Search fallback failed: {repr(e)}')
+
+        # If playlist still not found, create it
         if playlist is None:
             try:
                 data = self.sp.user_playlist_create(
@@ -226,6 +259,7 @@ class MonthlyPlaylists:
             if data.get('type') != 'playlist':
                 return None
             playlist = Playlist(sp=self.sp, playlist=data)
+            self.playlists.append(playlist)
             print(playlist.name, 'was created')
         return playlist
 

--- a/main.py
+++ b/main.py
@@ -68,7 +68,7 @@ class Playlist:
         :return: True for success, False otherwise.
         """
 
-        self.songs = []
+        collected = []
         offset = 0
         limit = 100
 
@@ -82,11 +82,12 @@ class Playlist:
                 return False
             if 'items' not in results:
                 return False
-            self.songs.extend(Song(x) for x in results['items'])
+            collected.extend(Song(x) for x in results['items'])
             if len(results['items']) < limit:
                 break
             offset += limit
 
+        self.songs = collected
         return True
 
 


### PR DESCRIPTION
## Changes

- **Add owner_id tracking**: Store playlist owner ID in Playlist class to distinguish between playlists with the same name
- **Implement pagination**: Fetch all playlist items using limit/offset to handle playlists with 100+ songs
- **Add Spotify search fallback**: When a playlist isn't found in local listings, search via Spotify API to prevent creating duplicates
- **Improve playlist matching**: Only match playlists owned by the current user to avoid false positives
- **Track found playlists**: Add newly discovered playlists to the local cache

## Why

Previously, if a monthly playlist wasn't returned in the initial paginated playlist listing, the code would create a duplicate instead of finding and using the existing one. The search fallback ensures we always find existing playlists before creating new ones.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes playlist discovery/creation flow and adds additional Spotify API calls (pagination + search), which could affect rate limits and playlist selection in edge cases.
> 
> **Overview**
> Prevents duplicate monthly playlists by tightening playlist matching to *only* playlists owned by the current user (tracking `Playlist.owner_id`) and by adding a Spotify `search` fallback when the target playlist isn’t present in the locally fetched list.
> 
> Updates `Playlist.__fetch_songs` to paginate `playlist_items` (limit/offset) so playlists with >100 tracks are fully loaded before checking for existing songs, and caches playlists found/created by appending them to `self.playlists`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a6e2c960c27a40d73c3201796f4493e8c68880e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->